### PR TITLE
Only detect each file once in filename validator

### DIFF
--- a/Submit.java
+++ b/Submit.java
@@ -311,7 +311,7 @@ public class Submit {
     }
 
     private boolean validateFilenames() throws IOException {
-        List<String> r = new ArrayList<String>();
+        Set<String> r = new HashSet<String>();
         for (String fileName : getFilenames()) {
             try(FileReader file = new FileReader(fileName)) {
                 BufferedReader rd = new BufferedReader(file);


### PR DESCRIPTION
If the student for some reason has created an entry point and then commented it out for submission he or she will receive the error:

`Error: Multiple task files found (Dyck.java, Dyck.java).
       You need to make a new BlueJ project for each task.`

This pull request fixes this by using a Set for holding the filenames found.