### PR TITLE
Suggestion: Add try-catch to test case

### DIFF
--- a/tasks/dyck/Dyck.java
+++ b/tasks/dyck/Dyck.java
@@ -257,14 +257,19 @@ public class Dyck {
         ArrayList<Character> list = new ArrayList<>();
         for (char c : input) list.add(c);
 
-        boolean output = new Dyck().checkParentheses(list);
+        try {
+            boolean output = new Dyck().checkParentheses(list);
 
-        if (output != correctAnswer)
-            outputFail("test14",
-                       "Expected output " + correctAnswer +
-                       " but got " + output);
-        else
-            outputPass("test14");
+            if (output != correctAnswer)
+                outputFail("test14",
+                           "Expected output " + correctAnswer +
+                           " but got " + output);
+            else
+                outputPass("test14");
+        } catch (Exception e) {
+                outputFail("test14",
+                           "Runtime execution: " + e);
+        }
     }
 
     public static void test15() {

--- a/tasks/dyck/Dyck.java
+++ b/tasks/dyck/Dyck.java
@@ -268,7 +268,7 @@ public class Dyck {
                 outputPass("test14");
         } catch (Exception e) {
                 outputFail("test14",
-                           "Runtime execution: " + e);
+                           "Exception: " + e);
         }
     }
 


### PR DESCRIPTION
This particular test will often fail with an exception. I suggest adding a try-catch to catch this exception, so the remainder of the tests can be executed. This could be done to all the tests.

If the students have not seen try-catch yet, then the obvious draw-back is that the test methods contain features they may not be familiar with.